### PR TITLE
Add terminal companions and refine command menu

### DIFF
--- a/spirits/johny.py
+++ b/spirits/johny.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import sqlite3
+
+
+@dataclass
+class Companion:
+    """Simple companion that logs all messages to a SQLite database."""
+
+    name: str = "johny"
+
+    def __post_init__(self) -> None:
+        data_dir = Path.home() / ".letsgo"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = data_dir / f"{self.name}.sqlite"
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS log (ts TEXT, role TEXT, message TEXT)"
+        )
+        self.conn.commit()
+
+    def record(self, role: str, message: str) -> None:
+        self.conn.execute(
+            "INSERT INTO log VALUES (?, ?, ?)",
+            (datetime.utcnow().isoformat(), role, message),
+        )
+        self.conn.commit()
+
+    def start(self, last_command: str) -> str:
+        reply = f"кажется, ты пытался выполнить '{last_command}'. давай разберёмся."
+        self.record("system", reply)
+        return reply
+
+    def stop(self) -> str:
+        reply = "companion disengaged."
+        self.record("system", reply)
+        return reply
+
+    def respond(self, text: str) -> str:
+        self.record("user", text)
+        reply = f"johny: {text}"
+        self.record("assistant", reply)
+        return reply

--- a/spirits/tony.py
+++ b/spirits/tony.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import sqlite3
+
+
+@dataclass
+class Companion:
+    """Deep explaining companion logging everything to SQLite."""
+
+    name: str = "tony"
+
+    def __post_init__(self) -> None:
+        data_dir = Path.home() / ".letsgo"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = data_dir / f"{self.name}.sqlite"
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS log (ts TEXT, role TEXT, message TEXT)"
+        )
+        self.conn.commit()
+
+    def record(self, role: str, message: str) -> None:
+        self.conn.execute(
+            "INSERT INTO log VALUES (?, ?, ?)",
+            (datetime.utcnow().isoformat(), role, message),
+        )
+        self.conn.commit()
+
+    def start(self, last_command: str) -> str:
+        reply = f"похоже, команда '{last_command}' вызвала вопросы. погружаемся глубже."
+        self.record("system", reply)
+        return reply
+
+    def stop(self) -> str:
+        reply = "xplainer disengaged."
+        self.record("system", reply)
+        return reply
+
+    def respond(self, text: str) -> str:
+        self.record("user", text)
+        reply = f"tony: {text}"
+        self.record("assistant", reply)
+        return reply

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -156,9 +156,9 @@ def test_help_lists_command_descriptions():
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/clear" in output
-    assert "clear the terminal screen" in output
+    assert "clear the terminal" in output
     assert "/history" in output
-    assert "show command history" in output
+    assert "command history" in output
 
 
 def test_help_specific_command():
@@ -198,12 +198,3 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
-
-
-def test_color_setting_persisted(tmp_path, monkeypatch):
-    config = tmp_path / "config"
-    monkeypatch.setattr(letsgo, "CONFIG_PATH", config)
-    monkeypatch.setattr(letsgo, "SETTINGS", letsgo.Settings())
-    monkeypatch.setattr(letsgo, "USE_COLOR", True)
-    asyncio.run(letsgo.handle_color("/color off"))
-    assert "use_color=False" in config.read_text()


### PR DESCRIPTION
## Summary
- add Johny and Tony companions that log session data and chat via `/dive` and `/deepdive`
- streamline command menu wording, move companion commands to the top, and remove `/color`
- show `Cleared.` on `/clear` and adjust tests for new descriptions

## Testing
- `pip install flake8 black pytest` *(failed: 403 Forbidden)*
- `apt-get update` *(failed: 403 Forbidden)*
- `./run-tests.sh` *(failed: flake8: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689645692e748329a353ca0192003b1a