### PR TITLE
Introduce companion chat utilities and refine command set

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,12 @@ The terminal, invoked after login, serves as the shell for Arianna Core.
 	•	Logs: Each session logs to /arianna_core/log/, stamped with UTC.
 	•	max_log_files option in ~/.letsgo/config to limit disk usage.
 	•	History: /arianna_core/log/history persists command history, loaded at startup, updated on exit.
-	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /summarize, /search, /color, /help.
+	•	Tab completion (readline): suggests built-in verbs — /dive, /deepdive, /diveoff, /status, /time, /run, /summarize, /search, /help.
 	•	/status: Reports CPU cores, uptime (from /proc/uptime), and current IP.
 	•	/summarize: Searches logs (with regex), prints last five matches; --history searches command history; /search <pattern> finds all matches.
 	•	/time: Prints current UTC.
 	•	/run : Executes shell command.
 	•	/help: Lists verbs.
-	•	/color on|off: Toggles colored output.
 	•	Unrecognized input: echoed back.
 	•	Structure ready for more advanced NLP (text hooks dispatch to remote models).
 

--- a/bridge.py
+++ b/bridge.py
@@ -39,7 +39,11 @@ import uvicorn
 
 PROMPT = ">>"
 
-MAIN_COMMANDS = [cmd for cmd in ("/status", "/time", "/help") if cmd in CORE_COMMANDS]
+MAIN_COMMANDS = [
+    cmd
+    for cmd in ("/dive", "/deepdive", "/diveoff", "/status", "/time", "/help")
+    if cmd in CORE_COMMANDS
+]
 
 
 def build_main_keyboard() -> InlineKeyboardMarkup:
@@ -401,10 +405,7 @@ async def start_bot() -> None:
     persistence_path = os.getenv("TELEGRAM_PERSISTENCE", "telegram_state.pkl")
     persistence = PicklePersistence(filepath=persistence_path)
     application = ApplicationBuilder().token(token).persistence(persistence).build()
-    commands = [
-        BotCommand(cmd[1:], desc.lower()) for cmd, (_, desc) in CORE_COMMANDS.items()
-    ]
-    commands.append(BotCommand("history", "show command history"))
+    commands = [BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()]
     await application.bot.set_my_commands(commands)
     terminal_url = os.getenv("WEB_TERMINAL_URL", "").strip()
     if terminal_url:

--- a/spirits/__init__.py
+++ b/spirits/__init__.py
@@ -1,0 +1,5 @@
+"""Companion spirits modules."""
+
+from . import johny, tony
+
+__all__ = ["johny", "tony"]

--- a/spirits/johny.py
+++ b/spirits/johny.py
@@ -1,0 +1,37 @@
+"""Johny companion module."""
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+DB_PATH = Path.home() / ".letsgo" / "spirits.db"
+
+
+def _ensure_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS johny (ts TEXT, msg TEXT)"
+        )
+        conn.commit()
+
+
+def record(text: str) -> None:
+    """Persist ``text`` in the johny table."""
+    _ensure_db()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO johny (ts, msg) VALUES (?, ?)",
+            (datetime.utcnow().isoformat(), text),
+        )
+        conn.commit()
+
+
+def start_chat(last_cmd: str) -> str:
+    """Return the initial message when chat starts."""
+    return f"There seems to be a problem with '{last_cmd}'. Let's sort it out."
+
+
+def chat(message: str) -> str:
+    """Very small echo-style chat."""
+    return f"Johny: {message}"

--- a/spirits/tony.py
+++ b/spirits/tony.py
@@ -1,0 +1,37 @@
+"""Tony companion module."""
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+DB_PATH = Path.home() / ".letsgo" / "spirits.db"
+
+
+def _ensure_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS tony (ts TEXT, msg TEXT)"
+        )
+        conn.commit()
+
+
+def record(text: str) -> None:
+    """Persist ``text`` in the tony table."""
+    _ensure_db()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO tony (ts, msg) VALUES (?, ?)",
+            (datetime.utcnow().isoformat(), text),
+        )
+        conn.commit()
+
+
+def start_chat(last_cmd: str) -> str:
+    """Return the initial message when deep chat starts."""
+    return f"Diving deep into '{last_cmd}'. Here's the breakdown."
+
+
+def chat(message: str) -> str:
+    """Echo-style deep explanation."""
+    return f"Tony: {message}"

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -156,9 +156,9 @@ def test_help_lists_command_descriptions():
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/clear" in output
-    assert "clear the terminal screen" in output
+    assert "clear the terminal" in output
     assert "/history" in output
-    assert "show command history" in output
+    assert "command history" in output
 
 
 def test_help_specific_command():
@@ -200,10 +200,3 @@ def test_handle_py_timeout(monkeypatch):
         assert colored is not None
 
 
-def test_color_setting_persisted(tmp_path, monkeypatch):
-    config = tmp_path / "config"
-    monkeypatch.setattr(letsgo, "CONFIG_PATH", config)
-    monkeypatch.setattr(letsgo, "SETTINGS", letsgo.Settings())
-    monkeypatch.setattr(letsgo, "USE_COLOR", True)
-    asyncio.run(letsgo.handle_color("/color off"))
-    assert "use_color=False" in config.read_text()


### PR DESCRIPTION
## Summary
- Add Johny and Tony companions that log all input and offer /dive and /deepdive chat modes with /diveoff to exit
- Simplify command descriptions, drop /color, and adjust /clear output
- Update Telegram bot menu to surface companion commands first

## Testing
- `./run-tests.sh` *(fails: flake8 missing)*
- `pip install flake8` *(fails: Could not connect to proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689645692e748329a353ca0192003b1a