### PR TITLE
Prioritize Tommy commands and ensure xplaine dependency

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -486,12 +486,15 @@ async def handle_ping(_: str) -> Tuple[str, str | None]:
     reply = "pong"
     return reply, reply
 
+
 async def handle_xplaine(_: str) -> Tuple[str, str | None]:
     global COMPANION_ACTIVE
     COMPANION_ACTIVE = True
     last_cmd = tommy.get_last_user_command()
     prefix = (
-        f"There were problems with '{last_cmd}'.\n" if last_cmd else "There were problems with your last command.\n"
+        f"There were problems with '{last_cmd}'.\n"
+        if last_cmd
+        else "There were problems with your last command.\n"
     )
     advice = await tommy.xplaine()
     reply = prefix + advice
@@ -506,6 +509,8 @@ async def handle_xplaineoff(_: str) -> Tuple[str, str | None]:
 
 
 CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
+    "/xplaine": (handle_xplaine, "ask companion"),
+    "/xplaineoff": (handle_xplaineoff, "companion off"),
     "/status": (handle_status, "show system metrics"),
     "/cpu": (handle_cpu, "show CPU load"),
     "/disk": (handle_disk, "disk usage"),
@@ -519,8 +524,6 @@ CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
     "/help": (handle_help, "help message"),
     "/search": (handle_search, "search command history"),
     "/ping": (handle_ping, "reply with pong"),
-    "/xplaine": (handle_xplaine, "ask companion"),
-    "/xplaineoff": (handle_xplaineoff, "companion off"),
 }
 
 COMMAND_HELP: Dict[str, str] = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 python-telegram-bot
 python-multipart
+aiohttp


### PR DESCRIPTION
## Summary
- Move Tommy companion commands to the top of the command menu
- Add missing aiohttp dependency to prevent xplaine module errors

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp)*
- `flake8 .` *(fails: command not found)*
- `black --check .` *(fails: would reformat tommy.py, bridge.py)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896481b85dc8329807586d2790032ac