### PR TITLE
Fix xplaine chat mode

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -401,9 +401,7 @@ async def start_bot() -> None:
     persistence_path = os.getenv("TELEGRAM_PERSISTENCE", "telegram_state.pkl")
     persistence = PicklePersistence(filepath=persistence_path)
     application = ApplicationBuilder().token(token).persistence(persistence).build()
-    commands = [
-        BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()
-    ]
+    commands = [BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()]
     commands.append(BotCommand("history", "command history"))
     await application.bot.set_my_commands(commands)
     terminal_url = os.getenv("WEB_TERMINAL_URL", "").strip()
@@ -423,6 +421,9 @@ async def start_bot() -> None:
     )
     application.add_handler(run_conv)
     application.add_handler(MessageHandler(filters.ATTACHMENT, handle_file))
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_telegram)
+    )
     application.add_handler(MessageHandler(filters.COMMAND, handle_telegram))
     application.add_handler(CallbackQueryHandler(handle_callback))
     await application.initialize()

--- a/letsgo.py
+++ b/letsgo.py
@@ -490,12 +490,8 @@ async def handle_ping(_: str) -> Tuple[str, str | None]:
 async def handle_xplaine(_: str) -> Tuple[str, str | None]:
     global COMPANION_ACTIVE
     COMPANION_ACTIVE = True
-    last_cmd = tommy.get_last_user_command()
-    prefix = (
-        f"There were problems with '{last_cmd}'.\n"
-        if last_cmd
-        else "There were problems with your last command.\n"
-    )
+    last_cmd = tommy.get_last_user_command(2)
+    prefix = f"Analyzing '{last_cmd}'.\n" if last_cmd else ""
     advice = await tommy.xplaine()
     reply = prefix + advice
     return reply, reply


### PR DESCRIPTION
## Summary
- track previous user commands for `/xplaine` analysis
- enable free-form Telegram messages during companion chat
- start chat mode with neutral analysis message

## Testing
- `black --check tommy.py letsgo.py bridge.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964c5bc5208329b8204bcfd144ebc6