### PR TITLE
Ensure Telegram polling by clearing leftover webhook

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -401,6 +401,7 @@ async def start_bot() -> None:
     persistence_path = os.getenv("TELEGRAM_PERSISTENCE", "telegram_state.pkl")
     persistence = PicklePersistence(filepath=persistence_path)
     application = ApplicationBuilder().token(token).persistence(persistence).build()
+    await application.bot.delete_webhook(drop_pending_updates=True)
     commands = [BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()]
     commands.append(BotCommand("history", "command history"))
     await application.bot.set_my_commands(commands)


### PR DESCRIPTION
## Summary
- clear existing webhook before starting Telegram polling to avoid `getUpdates` conflicts

## Testing
- `flake8` *(fails: command not found)*
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965ba097c883299a448fd4bb08e958