### PR TITLE
Fix /xplaine handling for Tommy

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -490,11 +490,8 @@ async def handle_ping(_: str) -> Tuple[str, str | None]:
 async def handle_xplaine(_: str) -> Tuple[str, str | None]:
     global COMPANION_ACTIVE
     COMPANION_ACTIVE = True
-    last_cmd = tommy.get_last_user_command(2)
-    prefix = f"Analyzing '{last_cmd}'.\n" if last_cmd else ""
     advice = await tommy.xplaine()
-    reply = prefix + advice
-    return reply, reply
+    return advice, advice
 
 
 async def handle_xplaineoff(_: str) -> Tuple[str, str | None]:


### PR DESCRIPTION
## Summary
- ensure Tommy analyzes the command prior to /xplaine and greets if none
- simplify /xplaine handler to enable chat without confusing Tommy

## Testing
- `black --check .`
- `python -m pytest`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e8734b0483298457c44c53670a55