### PR TITLE
Align /help command output with /start

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -330,12 +330,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    cmd = "/help"
-    if context.args:
-        cmd += " " + " ".join(context.args)
-    if update.message:
-        update.message.text = cmd
-    await handle_telegram(update, context)
+    await start(update, context)
 
 
 async def history_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- make `/help` command return the same welcome message and command list as `/start`

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `black --check bridge.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68998a331a2083299374ad73fc88e097