### PR TITLE
Handle missing subprocess in LetsGoProcess.stop

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -108,8 +108,14 @@ class LetsGoProcess:
         if self.proc and self.proc.stdin:
             self.proc.stdin.close()
         if self.proc:
-            self.proc.terminate()
-            await self.proc.wait()
+            try:
+                self.proc.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                await self.proc.wait()
+            except ProcessLookupError:
+                pass
             self.proc = None
 
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from bridge import LetsGoProcess
+
+
+class _DummyStdin:
+    def close(self) -> None:  # pragma: no cover
+        pass
+
+
+class _DummyProcess:
+    def __init__(self) -> None:
+        self.stdin = _DummyStdin()
+
+    def terminate(self) -> None:
+        raise ProcessLookupError
+
+    async def wait(self) -> None:
+        raise ProcessLookupError
+
+
+def test_stop_handles_missing_process():
+    proc = LetsGoProcess()
+    proc.proc = _DummyProcess()
+    asyncio.run(proc.stop())
+    assert proc.proc is None


### PR DESCRIPTION
## Summary
- avoid ProcessLookupError when stopping a missing letsgo subprocess
- add regression test for stopping when subprocess is already gone

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8 black pytest` *(fails: Could not connect to proxy)*
- `black --check bridge.py tests/test_bridge.py`
- `pytest tests/test_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d9a934c08329906775373f6a3790